### PR TITLE
Fix README error with iapetus-dev -> iapetus

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd iapetus
 ```bash
 conda install --yes conda-build
 conda build devtools/conda-recipe
-conda install --use-local iapetus-dev
+conda install --use-local iapetus
 ```
 
 ## Examples


### PR DESCRIPTION
## Description
The README erroneously instructed users to `conda install iapetus-dev` instead of `iapetus`. This PR fixes the README.

## Status
- [x] Ready to go