### PR TITLE
Add rudimentary resume capacity; change defaults

### DIFF
--- a/iapetus/iapetus.py
+++ b/iapetus/iapetus.py
@@ -601,10 +601,10 @@ def main():
     simulation = SimulatePermeation(gromacs_input_path=gromacs_input_path, ligand_resseq=ligand_resseq, output_filename=output_filename, verbose=args.verbose)
     resume = os.path.exists(output_filename)
 
-    if not resume:
-        simulation.n_iterations = args.n_iterations
-        simulation.n_steps_per_iteration = args.n_steps_per_iteration
+    simulation.n_iterations = args.n_iterations
+    simulation.n_steps_per_iteration = args.n_steps_per_iteration
 
+    if not resume:
         if args.testmode:
             simulation.pressure = None
             simulation.anneal_ligand = False

--- a/iapetus/iapetus.py
+++ b/iapetus/iapetus.py
@@ -591,10 +591,9 @@ def main():
     output_filename = os.path.abspath(args.output_filename)
 
     simulation = SimulatePermeation(gromacs_input_path=gromacs_input_path, ligand_resseq=ligand_resseq, output_filename=output_filename, verbose=args.verbose)
-    if os.path.exists(output_filename):
-        resume = True
+    resume = os.path.exists(output_filename)
 
-    else:
+    if not resume:
         simulation.n_iterations = args.n_iterations
         simulation.n_steps_per_iteration = args.n_steps_per_iteration
 

--- a/iapetus/iapetus.py
+++ b/iapetus/iapetus.py
@@ -161,7 +161,7 @@ class SimulatePermeation(object):
                                sampler_states=[self.sampler_state], initial_thermodynamic_states=[initial_state_index],
                                storage=self.reporter)
 
-    def run(self, platform_name=None, precision='auto', max_n_contexts=None, resume=False):
+    def run(self, platform_name=None, precision='auto', max_n_contexts=None, resume=False, extend=None):
         """
         Run the sampler for a specified number of iterations
 
@@ -196,12 +196,10 @@ class SimulatePermeation(object):
             from yank.multistate import SAMSSampler, MultiStateReporter
             sampler = SAMSSampler.from_storage(self.output_filename)
             # Run the remainder of the simulation
-            if (self.n_extend is None):
+            if (extend is None):
                 sampler.run()
-            if (self.n_extend is 0):
-                raise ValueError('The number of iterations for extending the simulation is {}'.format(self.n_extend)
             else:
-                sampler.extend(n_iterations=self.n_extend)
+                sampler.extend(n_iterations=self.n_iterations)
 
 
         else:
@@ -581,8 +579,8 @@ def main():
                         help='Number of timesteps per iteration (default: 1250)')
     parser.add_argument('--testmode', dest='testmode', action='store_true', default=False,
                         help='Run a vacuum simulation for testing')
-    parser.add_argument('--n_extend', dest='n_extend', action='store', type=int,
-                        help='number of iterations to extend a simulation')
+    parser.add_argument('--extend', dest='extend', action='store_true', default=None,
+                        help='Extend a simulation')
 
 
     args = parser.parse_args()
@@ -603,7 +601,7 @@ def main():
 
     simulation = SimulatePermeation(gromacs_input_path=gromacs_input_path, ligand_resseq=ligand_resseq, output_filename=output_filename, verbose=args.verbose)
     resume = os.path.exists(output_filename)
-    simulation.n_extend = args.n_extend
+    extend = args.extend
     if not resume:
         simulation.n_iterations = args.n_iterations
         simulation.n_steps_per_iteration = args.n_steps_per_iteration
@@ -613,7 +611,7 @@ def main():
             simulation.anneal_ligand = False
 
     # Run the simulation
-    simulation.run(platform_name=args.platform, precision=args.precision, max_n_contexts=args.max_n_contexts, resume=resume, n_extend=n_extend)
+    simulation.run(platform_name=args.platform, precision=args.precision, max_n_contexts=args.max_n_contexts, resume=resume, extend=extend)
 
 if __name__ == "__main__":
     # Do something if this file is invoked on its own

--- a/iapetus/iapetus.py
+++ b/iapetus/iapetus.py
@@ -159,7 +159,7 @@ class SimulatePermeation(object):
                                sampler_states=[self.sampler_state], initial_thermodynamic_states=[initial_state_index],
                                storage=self.reporter)
 
-    def run(self, platform_name=None, precision='auto', max_n_contexts=None,resume=False):
+    def run(self, platform_name=None, precision='auto', max_n_contexts=None, resume=False):
         """
         Run the sampler for a specified number of iterations
 
@@ -190,9 +190,9 @@ class SimulatePermeation(object):
 
         if resume:
             # Resume the simulation
-            print('Storage {} exists; resuming...'.format(output_filename))
+            print('Storage {} exists; resuming...'.format(self.output_filename))
             from yank.multistate import SAMSSampler, MultiStateReporter
-            sampler = SAMSSampler.from_storage(output_filename)
+            sampler = SAMSSampler.from_storage(self.output_filename)
             # Run the remainder of the simulation
             sampler.run()
 

--- a/iapetus/iapetus.py
+++ b/iapetus/iapetus.py
@@ -53,12 +53,12 @@ class SimulatePermeation(object):
             If True, print verbose output
 
         """
-        self._setup_complete = False
-
         # Setup general logging
         logging.root.setLevel(logging.DEBUG)
         logging.basicConfig(level=logging.DEBUG)
         yank.utils.config_root_logger(verbose=verbose, log_file_path=None)
+
+        self._setup_complete = False
 
         # Set default parameters
         self.temperature = 310.0 * unit.kelvin
@@ -98,7 +98,6 @@ class SimulatePermeation(object):
         self.analysis_particle_indices = self.mdtraj_topology.select('not water')
 
         # Store output filename
-        # TODO: Check if file already exists and resume if so
         self.output_filename = output_filename
 
         # Store ligand resseq
@@ -160,7 +159,7 @@ class SimulatePermeation(object):
                                sampler_states=[self.sampler_state], initial_thermodynamic_states=[initial_state_index],
                                storage=self.reporter)
 
-    def run(self, platform_name=None, precision='auto', max_n_contexts=None):
+    def run(self, platform_name=None, precision='auto', max_n_contexts=None,resume=False):
         """
         Run the sampler for a specified number of iterations
 
@@ -172,7 +171,8 @@ class SimulatePermeation(object):
             Precision to use, or None to automatically select ('mixed' is used if supported)
         max_n_contexts : int, optional, default=None
             Maximum number of contexts to use
-
+        resume : bool, default=False
+                    If True, resume simulation
         """
         # Configure ContextCache, platform and precision
         from yank.experiment import ExperimentBuilder
@@ -188,12 +188,21 @@ class SimulatePermeation(object):
         if max_n_contexts is not None:
             openmmtools.cache.global_context_cache.capacity = max_n_contexts
 
-        # Set up the simulation if it has not yet been set up
-        if not self._setup_complete:
-            self._setup()
+        if resume:
+            # Resume the simulation
+            print('Storage {} exists; resuming...'.format(output_filename))
+            from yank.multistate import SAMSSampler, MultiStateReporter
+            sampler = SAMSSampler.from_storage(output_filename)
+            # Run the remainder of the simulation
+            sampler.run()
 
-        # Run the simulation
-        self.simulation.run()
+        else:
+            # Set up the simulation if it has not yet been set up
+            if not self._setup_complete:
+                self._setup()
+
+                # Run the simulation
+                self.simulation.run()
 
     def _create_thermodynamic_states(self, reference_thermodynamic_state, spacing=0.25*unit.angstroms):
         """
@@ -581,19 +590,11 @@ def main():
     # Determine output filename
     output_filename = os.path.abspath(args.output_filename)
 
+    simulation = SimulatePermeation(gromacs_input_path=gromacs_input_path, ligand_resseq=ligand_resseq, output_filename=output_filename, verbose=args.verbose)
     if os.path.exists(output_filename):
-        # Resume the simulation
-        # TODO: Handle this within SimulatePermeation instead?
-        print('Storage {} exists; resuming...'.format(output_filename))
-        from yank.multistate import SAMSSampler, MultiStateReporter
-        sampler = SAMSSampler.from_storage(output_filename)
-
-        # Run the remainder of the simulation
-        sampler.run()
+        resume = True
 
     else:
-        # Set up a new calculation
-        simulation = SimulatePermeation(gromacs_input_path=gromacs_input_path, ligand_resseq=ligand_resseq, output_filename=output_filename, verbose=args.verbose)
         simulation.n_iterations = args.n_iterations
         simulation.n_steps_per_iteration = args.n_steps_per_iteration
 
@@ -601,8 +602,8 @@ def main():
             simulation.pressure = None
             simulation.anneal_ligand = False
 
-        # Run the simulation
-        simulation.run(platform_name=args.platform, precision=args.precision, max_n_contexts=args.max_n_contexts)
+    # Run the simulation
+    simulation.run(platform_name=args.platform, precision=args.precision, max_n_contexts=args.max_n_contexts, resume=resume)
 
 if __name__ == "__main__":
     # Do something if this file is invoked on its own

--- a/iapetus/iapetus.py
+++ b/iapetus/iapetus.py
@@ -250,7 +250,7 @@ class SimulatePermeation(object):
         print('axis_distance: {}'.format(axis_distance))
 
         # Compute spacing and spring constant
-        expansion_factor = 1.2
+        expansion_factor = 1.3 # Modified by Ana
         nstates = int(expansion_factor * axis_distance / spacing) + 1
         print('nstates: {}'.format(nstates))
         sigma_y = axis_distance / float(nstates) # stddev of force-free fluctuations in y-axis
@@ -264,9 +264,9 @@ class SimulatePermeation(object):
         K_xz = self.kT / (sigma_xz**2) # spring constant
         print('in-plane sigma_xz = {:.3f} A'.format(sigma_xz / unit.angstroms))
 
-        dr = axis_distance * (expansion_factor - 1.0)/2.0
+        dr = axis_distance * (expansion_factor - 1.0)/1.0 # Modified by Ana
         rmax = axis_distance + dr
-        rmin = - dr
+        rmin = -1.0 * axis_distance # Modified by Ana
 
         # Create restraint state that encodes this axis
         # TODO: Rework this as CustomCVForce with in-plane and along-axis deviations as separate forces so we can store them each iteration


### PR DESCRIPTION
## Description

This PR adds a rudimentary way to resume simulations if the `.nc` file already exists.

Defaults are changed to longer simulations with more sampling between weight updates (500 -> 1250 steps/update).
